### PR TITLE
Fix: Calendar. Set displayedMonthIndex.

### DIFF
--- a/src/bunny.calendar.js
+++ b/src/bunny.calendar.js
@@ -338,7 +338,7 @@ export var CalendarController = {
 
     attachMonthSelectEvent: function(calendar_id) {
         Calendar._calendars[calendar_id].headerMonthSelect.addEventListener('change', function() {
-            Calendar.changeMonth(calendar_id, Calendar._calendars[calendar_id].displayedYear, this.value);
+            Calendar.changeMonth(calendar_id, Calendar._calendars[calendar_id].displayedYear, +this.value);
         });
     },
 


### PR DESCRIPTION
Hello!

After month change via select `displayedMonthIndex` became string value instead number. It generates errors in another parts of calendar (`Calendar.changeMonth`)