### PR TITLE
fix(Pagination) detect existence of question mark in URL in order to use correct parameter separator when adding parameters to the URL

### DIFF
--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -265,7 +265,12 @@ export const Pagination = {
     },
 
     addPageParamToUrl(url, page) {
-        return url + '?' + this._config.paramPage + '=' + page;
+        if (t.indexOf('?')!=-1) {
+            var paramsep = '&';
+        } else {
+            var paramsep = '?';
+        }
+        return url + paramsep + this._config.paramPage + '=' + page;
     },
 
     getPageFromUrl(url) {

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -265,7 +265,7 @@ export const Pagination = {
     },
 
     addPageParamToUrl(url, page) {
-        if (t.indexOf('?')!=-1) {
+        if (url.indexOf('?')!=-1) {
             var paramsep = '&';
         } else {
             var paramsep = '?';


### PR DESCRIPTION
The ajax URL I use to retrieve data has parameters:

```index.php?param1=val1&param2=val2....```

so when the pagination code adds the "page" parameter with a hardcoded question mark it doesn't work correctly. I added an "if" to detect the existence of a question mark in order to set the correct parameter separator and it is working correctly in both case.