### PR TITLE
feat(Datatable) make search input configurable to avoid conflicts

### DIFF
--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -19,6 +19,8 @@ export const DataTableConfig = {
 
   loadingImg: '/img/loading.svg',
 
+  searchInputName: 'search',
+
   ajaxHeaders: []
 };
 
@@ -27,7 +29,7 @@ export const DataTableUI = {
   Config: DataTableConfig,
   Template: Template,
 
-  getSearchInput(datatable, name = 'search') {
+  getSearchInput(datatable, name = DataTableConfig.searchInputName) {
     return datatable.querySelector('[name="' + name + '"]') || false;
   },
 


### PR DESCRIPTION
I have some conflicts with the default "search" input name so I made this change in order to be able to specify the search input element name.